### PR TITLE
Fix Issue #1: Inserting IPs creates a match for that IP and one IP earlier

### DIFF
--- a/src/main/java/com/github/x25/net/tree/IpSubnetTree.java
+++ b/src/main/java/com/github/x25/net/tree/IpSubnetTree.java
@@ -68,7 +68,7 @@ public class IpSubnetTree<V> {
         int pos = cidrNotation.indexOf('/');
 
         if (pos == -1) {
-            insert(cidrNotation + "/255", value);
+            insert(cidrNotation + "/32", value);
             return;
         }
 

--- a/src/test/java/com/github/x25/IpSubnetTreeTest.java
+++ b/src/test/java/com/github/x25/IpSubnetTreeTest.java
@@ -41,6 +41,16 @@ public class IpSubnetTreeTest extends TestCase {
         assertEquals("X", tree.find("128.0.0.1"));
     }
 
+    public void testNoCidr() {
+        IpSubnetTree<String> tree = new IpSubnetTree<String>();
+        tree.setDefaultValue("X");
+        tree.insert("129.0.0.7", "F");
+
+        assertEquals("X", tree.find("129.0.0.6"));
+        assertEquals("F", tree.find("129.0.0.7"));
+        assertEquals("X", tree.find("129.0.0.6"));
+    }
+
     public void testCidr() {
         IpSubnetTree<Integer> tree = new IpSubnetTree<Integer>();
         for (int i = 0; i < 255; i++) {


### PR DESCRIPTION
Fix bug where inserting an IP without a CIDR extension would end up with two entries in the tree instead of just the expected one.

See https://github.com/x25/ip-subnet-tree/issues/1